### PR TITLE
Setup e2e tests actions to test MSF server and latest OpenMRS release depending on the served server url

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -2,6 +2,10 @@ name: Run E2E Tests on PRs
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
 
 jobs:
   build:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,158 @@
+name: Run E2E Tests on Release PRs
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+      branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      patient_management_ref: ${{steps.refs.outputs.patient_management}}
+      patient_chart_ref: ${{steps.refs.outputs.patient_chart}}
+      esm_core_ref: ${{steps.refs.outputs.esm_core}}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and Run Containers
+        run: docker-compose -f distro/e2e_test_support_files/docker-compose-build.yml up -d
+
+      - name: Wait for the backend to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+
+      - name: Commit and export Containers
+        run: sh distro/e2e_test_support_files/commit_and_export_images.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e_release_env_images
+          path: e2e_release_env_images.tar.gz
+          retention-days: 1
+
+  run-patient-management-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Temporary Directory to Download Docker Images
+        id: tempdir
+        run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
+
+      - name: Download Docker Images
+        uses: actions/download-artifact@v3
+        with:
+          name: e2e_release_env_images
+          path: ${{ steps.tempdir.outputs.tmpdir }}
+
+      - name: Load Docker Images
+        run: |
+          gzip -d ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar.gz
+          docker load --input ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar
+          docker image ls -a
+
+      - name: Spin up an OpenMRS Instance
+        run: docker-compose up -d
+        working-directory: distro/e2e_test_support_files
+
+      - name: Checkout to the Repo's Tag
+        uses: actions/checkout@v4
+        with:
+          repository: openmrs/openmrs-esm-patient-management
+          ref: ${{ needs.build.outputs.patient_management_ref }}
+          path: e2e_repo
+
+      - name: Copy test environment variables
+        run: cp example.env .env
+        working-directory: e2e_repo
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+        working-directory: e2e_repo
+
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e_repo
+
+      - name: Wait for the OpenMRS instance to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+
+      - name: Run E2E tests
+        run: yarn playwright test
+        working-directory: e2e_repo
+
+      - name: Upload Report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: report-patient-management
+          path: e2e_repo/playwright-report/
+          retention-days: 30
+
+  run-patient-chart-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Temporary Directory to Download Docker Images
+        id: tempdir
+        run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
+
+      - name: Download Docker Images
+        uses: actions/download-artifact@v3
+        with:
+          name: e2e_release_env_images
+          path: ${{ steps.tempdir.outputs.tmpdir }}
+
+      - name: Load Docker Images
+        run: |
+          gzip -d ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar.gz
+          docker load --input ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar
+          docker image ls -a
+
+      - name: Spin up an OpenMRS Instance
+        run: docker-compose up -d
+        working-directory: distro/e2e_test_support_files
+
+      - name: Checkout to the Repo's Tag
+        uses: actions/checkout@v4
+        with:
+          repository: openmrs/openmrs-esm-patient-chart
+          ref: ${{ needs.build.outputs.patient_chart_ref }}
+          path: e2e_repo
+
+      - name: Copy test environment variables
+        run: cp example.env .env
+        working-directory: e2e_repo
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+        working-directory: e2e_repo
+
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e_repo
+
+      - name: Wait for the OpenMRS instance to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+
+      - name: Run E2E tests
+        run: yarn playwright test
+        working-directory: e2e_repo
+
+      - name: Upload Report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: report-patient-chart
+          path: e2e_repo/playwright-report/
+          retention-days: 30

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -2,10 +2,6 @@ name: Run E2E Tests on PRs
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main, dev]
-  push:
-      branches: [main, dev]
 
 jobs:
   build:
@@ -193,7 +189,7 @@ jobs:
 
       - name: Spin up an OpenMRS Instance
         run: docker-compose up -d
-        working-directory: e2e_test_support_files
+        working-directory: distro/e2e_test_support_files
 
       - name: Checkout to the Repo's Tag
         uses: actions/checkout@v4

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -2,9 +2,9 @@ name: Run E2E Tests on Release PRs
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-      branches: [main]
+      branches: [main, dev]
 
 jobs:
   build:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -24,6 +24,10 @@ jobs:
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')" >> $GITHUB_ENV
 
+      - name: Extract version numbers from the spa-build-config.json file
+        id: refs
+        run: bash distro/e2e_test_support_files/extract_tag_numbers.sh
+
       - name: Build and Run Containers
         run: docker-compose -f distro/e2e_test_support_files/docker-compose-build.yml up -d
 
@@ -33,12 +37,11 @@ jobs:
       - name: Commit and export Containers
         run: sh distro/e2e_test_support_files/commit_and_export_images.sh
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: cache docker images
+        uses: actions/cache@v4
         with:
-          name: e2e_release_env_images
           path: e2e_release_env_images.tar.gz
-          retention-days: 1
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
   run-patient-management-e2e-tests:
     runs-on: ubuntu-latest
@@ -50,14 +53,15 @@ jobs:
         id: tempdir
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
-      - name: Download Docker Images
-        uses: actions/download-artifact@v3
+      - name: Get cached Docker Images
+        uses: actions/cache/restore@v3
         with:
-          name: e2e_release_env_images
-          path: ${{ steps.tempdir.outputs.tmpdir }}
+          path: e2e_release_env_images.tar.gz
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Load Docker Images
         run: |
+          cp e2e_release_env_images.tar.gz ${{ steps.tempdir.outputs.tmpdir }}
           gzip -d ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar.gz
           docker load --input ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar
           docker image ls -a
@@ -111,14 +115,15 @@ jobs:
         id: tempdir
         run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
-      - name: Download Docker Images
-        uses: actions/download-artifact@v3
+      - name: Get cached Docker Images
+        uses: actions/cache/restore@v3
         with:
-          name: e2e_release_env_images
-          path: ${{ steps.tempdir.outputs.tmpdir }}
+          path: e2e_release_env_images.tar.gz
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Load Docker Images
         run: |
+          cp e2e_release_env_images.tar.gz ${{ steps.tempdir.outputs.tmpdir }}
           gzip -d ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar.gz
           docker load --input ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar
           docker image ls -a
@@ -159,5 +164,68 @@ jobs:
         if: always()
         with:
           name: report-patient-chart
+          path: e2e_repo/playwright-report/
+          retention-days: 30
+
+
+  run-esm-core-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Temporary Directory to Download Docker Images
+        id: tempdir
+        run: echo "tmpdir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
+
+      - name: Get cached Docker Images
+        uses: actions/cache/restore@v3
+        with:
+          path: e2e_release_env_images.tar.gz
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+      - name: Load Docker Images
+        run: |
+          cp e2e_release_env_images.tar.gz ${{ steps.tempdir.outputs.tmpdir }}
+          gzip -d ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar.gz
+          docker load --input ${{ steps.tempdir.outputs.tmpdir }}/e2e_release_env_images.tar
+          docker image ls -a
+
+      - name: Spin up an OpenMRS Instance
+        run: docker-compose up -d
+        working-directory: e2e_test_support_files
+
+      - name: Checkout to the Repo's Tag
+        uses: actions/checkout@v4
+        with:
+          repository: openmrs/openmrs-esm-core
+          ref: ${{ needs.build.outputs.esm_core_ref }}
+          path: e2e_repo
+
+      - name: Copy test environment variables
+        run: cp example.env .env
+        working-directory: e2e_repo
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+        working-directory: e2e_repo
+
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e_repo
+
+      - name: Wait for the OpenMRS instance to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+
+      - name: Run E2E tests
+        run: yarn playwright test
+        working-directory: e2e_repo
+
+      - name: Upload Report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: report-esm-core
           path: e2e_repo/playwright-report/
           retention-days: 30

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,6 +1,7 @@
-name: Run E2E Tests on Release PRs
+name: Run E2E Tests on PRs
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main, dev]
   push:
@@ -18,6 +19,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')" >> $GITHUB_ENV
 
       - name: Build and Run Containers
         run: docker-compose -f distro/e2e_test_support_files/docker-compose-build.yml up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@
 FROM openmrs/openmrs-core:dev as dev
 WORKDIR /openmrs_distro
 
-ARG MVN_ARGS_SETTINGS="-s /usr/share/maven/ref/settings-docker.xml -U -P distro"
+ARG MVN_ARGS_SETTINGS="-s /usr/share/maven/ref/settings-docker.xml -U"
 ARG MVN_ARGS="install"
 
 # Copy build files
 COPY pom.xml ./
 COPY distro ./distro/
 
-# Build the distro, but only deploy from the amd64 build
-RUN --mount=type=secret,id=m2settings,target=/usr/share/maven/ref/settings-docker.xml if [[ "$MVN_ARGS" != "deploy" || "$(arch)" = "x86_64" ]]; then mvn $MVN_ARGS_SETTINGS $MVN_ARGS; else mvn $MVN_ARGS_SETTINGS install; fi
+# Build the distro
+RUN --mount=type=secret,id=m2settings,target=/root/.m2/settings.xml mvn $MVN_ARGS_SETTINGS $MVN_ARGS
 
 RUN cp /openmrs_distro/distro/target/sdk-distro/web/openmrs.war /openmrs/distribution/openmrs_core/
 
@@ -21,7 +21,7 @@ RUN cp -R /openmrs_distro/distro/target/sdk-distro/web/modules /openmrs/distribu
 RUN cp -R /openmrs_distro/distro/target/sdk-distro/web/owa /openmrs/distribution/openmrs_owas
 
 # Clean up after copying needed artifacts
-RUN mvn $MVN_ARGS_SETTINGS clean
+RUN mvn clean $MVN_ARGS_SETTINGS
 
 ### Run Stage
 # Replace 'nightly' with the exact version of openmrs-core built for production (if available)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@
 FROM openmrs/openmrs-core:dev as dev
 WORKDIR /openmrs_distro
 
-ARG MVN_ARGS_SETTINGS="-s /usr/share/maven/ref/settings-docker.xml -U"
+ARG MVN_ARGS_SETTINGS="-s /usr/share/maven/ref/settings-docker.xml -U -P distro"
 ARG MVN_ARGS="install"
 
 # Copy build files
 COPY pom.xml ./
 COPY distro ./distro/
 
-# Build the distro
-RUN --mount=type=secret,id=m2settings,target=/root/.m2/settings.xml mvn $MVN_ARGS_SETTINGS $MVN_ARGS
+# Build the distro, but only deploy from the amd64 build
+RUN --mount=type=secret,id=m2settings,target=/usr/share/maven/ref/settings-docker.xml if [[ "$MVN_ARGS" != "deploy" || "$(arch)" = "x86_64" ]]; then mvn $MVN_ARGS_SETTINGS $MVN_ARGS; else mvn $MVN_ARGS_SETTINGS install; fi
 
 RUN cp /openmrs_distro/distro/target/sdk-distro/web/openmrs.war /openmrs/distribution/openmrs_core/
 
@@ -21,7 +21,7 @@ RUN cp -R /openmrs_distro/distro/target/sdk-distro/web/modules /openmrs/distribu
 RUN cp -R /openmrs_distro/distro/target/sdk-distro/web/owa /openmrs/distribution/openmrs_owas
 
 # Clean up after copying needed artifacts
-RUN mvn clean $MVN_ARGS_SETTINGS
+RUN mvn $MVN_ARGS_SETTINGS clean
 
 ### Run Stage
 # Replace 'nightly' with the exact version of openmrs-core built for production (if available)

--- a/distro/e2e_test_support_files/README.md
+++ b/distro/e2e_test_support_files/README.md
@@ -1,0 +1,52 @@
+# Run E2E Tests on Release PRs
+
+This GitHub Actions workflow, named "Run E2E Tests on Release PRs," serves as Quality Gate #4 in the slide
+deck [O3 Release QA pipeline](https://docs.google.com/presentation/d/1k3DH74Mz1Afnrgy2MpwR5HQK5vMpVx0pTfN1na62lvI/edit#slide=id.g165af5ac0be_0_24).
+
+The workflow is designed to automate the end-to-end (E2E) testing process for release pull requests (PRs)
+that opened in the format described in
+here: [How to Release the O3 RefApp](https://wiki.openmrs.org/display/projects/How+to+Release+the+O3+RefApp)
+
+The workflow is conditional and **only runs if the pull request title starts with "(release)"**.
+
+Below is an overview of the key components of the workflow:
+<a href="https://ibb.co/g9GmpHL"><img src="https://i.ibb.co/MSbZ4Wx/Screenshot-2023-10-24-at-18-13-19.png" border="0"></a>
+
+## Job: build
+
+This job prepares the test environment, extracts version numbers, builds and runs Docker containers, and uploads
+artifacts for use in subsequent E2E testing jobs.
+
+### Checking out to the release commit
+
+The reason for the step:
+
+```yaml
+- name: Checkout to the release commit
+  run: git checkout 'HEAD^{/\(release\)}'
+```
+
+is to ensure that the workflow checks out to the specific release commit associated with the pull request. This is
+necessary because the pull request contain both release commits and revert commits, and the goal is to specifically
+target the release commit for further processing.
+
+## End-to-End Test Jobs
+
+The workflow includes several end-to-end test jobs, each corresponding to a specific components of O3 (frontend
+mono-repos). These jobs are structured similarly and are listed below:
+
+* `run-patient-management-e2e-tests`
+* `run-patient-chart-e2e-tests`
+* `run-form-builder-e2e-tests`
+* `run-esm-core-e2e-tests`
+* `run-cohort-builder-e2e-tests`
+
+In each "End-to-End Test Job," the workflow first checks out the repository associated with a specific OpenMRS
+component. It then downloads Docker images from a previous "build" job, loads these images, and starts an OpenMRS instance.
+
+### Why Check Out to the Tags?
+
+The workflow checks out a specific tagged version of the component's repository, the tag is imported from the previous "
+build" job. This is necessary because the goal is to perform end-to-end tests on the codebase that corresponds to a
+particular release version, rather than the code at the head of the repository. In case of using pre-releases, it checkouts
+to the main branch as we don't create tags for pre-releases.

--- a/distro/e2e_test_support_files/commit_and_export_images.sh
+++ b/distro/e2e_test_support_files/commit_and_export_images.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+backend_container_id=$(docker ps --filter "name=backend" --format "{{.ID}}")
+db_container_id=$(docker ps --filter "name=db" --format "{{.ID}}")
+frontend_container_id=$(docker ps --filter "name=frontend" --format "{{.ID}}")
+gateway_container_id=$(docker ps --filter "name=gateway" --format "{{.ID}}")
+
+docker commit $frontend_container_id frontend
+docker commit $gateway_container_id gateway
+docker commit $backend_container_id backend
+docker commit $db_container_id db
+
+docker save frontend gateway backend db > e2e_release_env_images.tar
+
+# compress the file (to decrease the upload file size)
+gzip -c e2e_release_env_images.tar > e2e_release_env_images.tar.gz

--- a/distro/e2e_test_support_files/docker-compose-build.yml
+++ b/distro/e2e_test_support_files/docker-compose-build.yml
@@ -1,0 +1,59 @@
+version: "3.8"
+
+services:
+  gateway:
+    build:
+      context: ../../gateway
+    container_name: gateway
+    restart: "unless-stopped"
+    depends_on:
+      - frontend
+      - backend
+    ports:
+      - "80:80"
+
+  frontend:
+    build:
+      context: ../../frontend
+    container_name: frontend
+    restart: "unless-stopped"
+    environment:
+      SPA_PATH: /openmrs/spa
+      API_URL: /openmrs
+      SPA_CONFIG_URLS:
+      SPA_DEFAULT_LOCALE:
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost/" ]
+      timeout: 5s
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ../../
+    container_name: backend
+    depends_on:
+      - db
+    environment:
+      OMRS_CONFIG_MODULE_WEB_ADMIN: "true"
+      OMRS_CONFIG_AUTO_UPDATE_DATABASE: "true"
+      OMRS_CONFIG_CREATE_TABLES: "true"
+      OMRS_CONFIG_CONNECTION_SERVER: db
+      OMRS_CONFIG_CONNECTION_DATABASE: openmrs
+      OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
+      OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/openmrs" ]
+      timeout: 5s
+
+  # MariaDB
+  db:
+    image: mariadb:10.8.2
+    container_name: db
+    command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --datadir=/openmrs-db"
+    environment:
+      MYSQL_DATABASE: openmrs
+      MYSQL_USER: ${OPENMRS_DB_USER:-openmrs}
+      MYSQL_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
+

--- a/distro/e2e_test_support_files/docker-compose-build.yml
+++ b/distro/e2e_test_support_files/docker-compose-build.yml
@@ -20,7 +20,7 @@ services:
     environment:
       SPA_PATH: /openmrs/spa
       API_URL: /openmrs
-      SPA_CONFIG_URLS:
+      SPA_CONFIG_URLS: /openmrs/spa/custom-config.json
       SPA_DEFAULT_LOCALE:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost/" ]

--- a/distro/e2e_test_support_files/docker-compose.yml
+++ b/distro/e2e_test_support_files/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  gateway:
+    image: gateway
+    restart: "unless-stopped"
+    depends_on:
+      - frontend
+      - backend
+    ports:
+      - "8080:80"
+
+  frontend:
+    image: frontend
+    restart: "unless-stopped"
+    depends_on:
+      - backend
+
+  backend:
+    image: backend
+    restart: "unless-stopped"
+
+  db:
+    image: db
+    restart: "unless-stopped"
+

--- a/distro/e2e_test_support_files/extract_tag_numbers.sh
+++ b/distro/e2e_test_support_files/extract_tag_numbers.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Define a function to extract and output a dependency value
+get_repository_tag() {
+  local file="$1"
+  local repo_name="$2"
+  local app="$3"
+
+  local version=$(awk -F'"' -v app="$app" '$0 ~ app {print $4}' "$file")
+  local ref="refs/tags/v$version"
+
+  # Check if the version number contains "pre" and modify the ref to main branch
+  if [[ $version == *"pre"* ]]; then
+    ref="main"
+  fi
+
+  echo "$repo_name=$ref"
+}
+
+file_path="frontend/spa-build-config.json"
+
+# Call the function for each Repository with the app as the second argument
+get_repository_tag "$file_path" "patient_management" "@openmrs/esm-patient-registration-app" >> "$GITHUB_OUTPUT"
+get_repository_tag "$file_path" "patient_chart" "@openmrs/esm-patient-chart-app" >> "$GITHUB_OUTPUT"
+get_repository_tag "$file_path" "esm_core" "@openmrs/esm-login-app" >> "$GITHUB_OUTPUT"
+get_repository_tag "$file_path" "form_builder" "@openmrs/esm-form-builder-app" >> "$GITHUB_OUTPUT"
+get_repository_tag "$file_path" "cohort_builder" "@openmrs/esm-cohort-builder-app" >> "$GITHUB_OUTPUT"

--- a/distro/e2e_test_support_files/extract_tag_numbers.sh
+++ b/distro/e2e_test_support_files/extract_tag_numbers.sh
@@ -10,18 +10,16 @@ get_repository_tag() {
   local ref="refs/tags/v$version"
 
   # Check if the version number contains "pre" and modify the ref to main branch
-  if [[ $version == *"pre"* ]]; then
+  if [[ $version == *"pre"* || $version == *"next"* ]]; then
     ref="main"
   fi
 
   echo "$repo_name=$ref"
 }
 
-file_path="frontend/spa-build-config.json"
+file_path="frontend/spa-assemble-config.json"
 
 # Call the function for each Repository with the app as the second argument
 get_repository_tag "$file_path" "patient_management" "@openmrs/esm-patient-registration-app" >> "$GITHUB_OUTPUT"
 get_repository_tag "$file_path" "patient_chart" "@openmrs/esm-patient-chart-app" >> "$GITHUB_OUTPUT"
 get_repository_tag "$file_path" "esm_core" "@openmrs/esm-login-app" >> "$GITHUB_OUTPUT"
-get_repository_tag "$file_path" "form_builder" "@openmrs/esm-form-builder-app" >> "$GITHUB_OUTPUT"
-get_repository_tag "$file_path" "cohort_builder" "@openmrs/esm-cohort-builder-app" >> "$GITHUB_OUTPUT"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,19 +9,19 @@ ARG APP_SHELL_VERSION=next
 RUN mkdir -p /app
 WORKDIR /app
 
-COPY /frontend/${ENVIRONMENT:-dev}/spa-assemble-config.json .
-COPY /frontend/${ENVIRONMENT:-dev}/spa-build-config.json .
+COPY ${ENVIRONMENT:-dev}/spa-assemble-config.json .
+COPY ${ENVIRONMENT:-dev}/spa-build-config.json .
 
 ARG CACHE_BUST
-RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} assemble --manifest --mode config --config spa-assemble-config.json --target ./spa
-RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} build --build-config spa-build-config.json --target ./spa
+RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} assemble --manifest --mode config --config ${ENVIRONMENT:-dev}/spa-assemble-config.json --target ./spa
+RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} build --build-config ${ENVIRONMENT:-dev}/spa-build-config.json --target ./spa
 RUN if [ ! -f ./spa/index.html ]; then echo 'Build failed. Please check the logs above for details. This may have happened because of an update to a library that OpenMRS depends on.'; exit 1; fi
 
-COPY /frontend/${ENVIRONMENT:-dev}/custom-config.json ./spa/custom-config.json
-COPY /frontend/${ENVIRONMENT:-dev}/assets/logo.png ./spa/logo.png
-COPY /frontend/${ENVIRONMENT:-dev}/assets/header-logo.png ./spa/header-logo.png
-COPY /frontend/${ENVIRONMENT:-dev}/assets/favicon.ico ./spa/favicon.ico
-COPY /frontend/${ENVIRONMENT:-dev}/assets/favicon-32x32.webp ./spa/favicon-32x32.webp
+COPY ${ENVIRONMENT:-dev}/custom-config.json ./spa/custom-config.json
+COPY ${ENVIRONMENT:-dev}/assets/logo.png ./spa/logo.png
+COPY ${ENVIRONMENT:-dev}/assets/header-logo.png ./spa/header-logo.png
+COPY ${ENVIRONMENT:-dev}/assets/favicon.ico ./spa/favicon.ico
+COPY ${ENVIRONMENT:-dev}/assets/favicon-32x32.webp ./spa/favicon-32x32.webp
 
 #--------------------------------------------
 # Runtime Stage - Published Image
@@ -36,10 +36,12 @@ RUN apk update && \
 # clear any default files installed by nginx
 RUN rm -rf /usr/share/nginx/html/*
 
-COPY /frontend/startup.sh /usr/local/bin/startup.sh
+COPY startup.sh /usr/local/bin/startup.sh
 RUN chmod +x /usr/local/bin/startup.sh
 
+COPY nginx.conf /etc/nginx/nginx.conf
+
 COPY --from=dev /app/spa /usr/share/nginx/html
-COPY /frontend/nginx.conf /etc/nginx/nginx.conf
+COPY ${ENVIRONMENT:-dev}/custom-config.json /usr/share/nginx/html
 
 CMD ["/usr/local/bin/startup.sh"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,8 +13,8 @@ COPY ${ENVIRONMENT:-dev}/spa-assemble-config.json .
 COPY ${ENVIRONMENT:-dev}/spa-build-config.json .
 
 ARG CACHE_BUST
-RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} assemble --manifest --mode config --config ${ENVIRONMENT:-dev}/spa-assemble-config.json --target ./spa
-RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} build --build-config ${ENVIRONMENT:-dev}/spa-build-config.json --target ./spa
+RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} assemble --manifest --mode config --config spa-assemble-config.json --target ./spa
+RUN npx --legacy-peer-deps openmrs@${APP_SHELL_VERSION:-next} build --build-config spa-build-config.json --target ./spa
 RUN if [ ! -f ./spa/index.html ]; then echo 'Build failed. Please check the logs above for details. This may have happened because of an update to a library that OpenMRS depends on.'; exit 1; fi
 
 COPY ${ENVIRONMENT:-dev}/custom-config.json ./spa/custom-config.json


### PR DESCRIPTION
In actions, we run e2e against our current msf server.  
Since OpenMRS will not always be running  `3.0.0-Beta 16` and we shall be pulling from the latest 

We can test OpenMRS  locally each time we need to upgrade msf images from the actions 

### Screenshot
<img width="1112" alt="Screenshot 2024-03-20 at 10 55 19" src="https://github.com/MSF-OCG/LIME-EMR-project-demo/assets/58003327/bb48fc79-ffdf-4e7c-a0e4-39182123e5b7">
<img width="1068" alt="Screenshot 2024-03-20 at 10 58 59" src="https://github.com/MSF-OCG/LIME-EMR-project-demo/assets/58003327/e0b5c932-b370-413a-905e-ed8a5208b848">
